### PR TITLE
Add scalable world generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # UnnamedHorrorGame
 PolygonForge and Mike Brogan - Horror Game Project on GoDot
+
+## World Generation
+
+The `scripts/world_generator.gd` script provides a scalable, open-world
+map generator. It builds a ground plane based on the configurable
+`map_size` property and spawns three medium-sized cabins at random
+locations. The `randomize()` call ensures that the layout is different on
+every restart.

--- a/scripts/world_generator.gd
+++ b/scripts/world_generator.gd
@@ -1,0 +1,37 @@
+extends Spatial
+
+## Configurable size of the map in world units. Increasing this makes the world larger.
+export (Vector3) var map_size = Vector3(300, 0, 300)
+
+## Number of cabins to generate.
+const CABIN_COUNT = 3
+
+## Size of each cabin mesh so that they count as "medium" in the world.
+const CABIN_SIZE = Vector3(10, 6, 10)
+
+func _ready():
+    randomize()
+    _generate_ground()
+    _spawn_cabins()
+
+func _generate_ground():
+    # Create a simple plane to serve as the world ground.
+    var ground = MeshInstance.new()
+    var mesh = PlaneMesh.new()
+    mesh.size = Vector2(map_size.x, map_size.z)
+    ground.mesh = mesh
+    add_child(ground)
+
+func _spawn_cabins():
+    # Spawn the required number of cabins at random positions inside the map bounds.
+    for i in CABIN_COUNT:
+        var cabin = MeshInstance.new()
+        var cube = CubeMesh.new()
+        cube.size = CABIN_SIZE
+        cabin.mesh = cube
+        cabin.translation = Vector3(
+            rand_range(-map_size.x * 0.5, map_size.x * 0.5),
+            CABIN_SIZE.y * 0.5,
+            rand_range(-map_size.z * 0.5, map_size.z * 0.5)
+        )
+        add_child(cabin)

--- a/scripts/world_generator_test.gd
+++ b/scripts/world_generator_test.gd
@@ -1,0 +1,7 @@
+extends SceneTree
+
+func _init():
+    var WorldGenerator = load("res://scripts/world_generator.gd")
+    var world = WorldGenerator.new()
+    world._ready()
+    quit()


### PR DESCRIPTION
## Summary
- add world generator script that builds a scalable map and random cabins
- document world generation usage

## Testing
- `godot3-server --headless --script scripts/world_generator_test.gd` *(fails: memory leaks and resource warnings)*